### PR TITLE
Specify the SHA256 digest algorithm when signing

### DIFF
--- a/enclavekey/sign.go
+++ b/enclavekey/sign.go
@@ -57,7 +57,7 @@ func (k *Key) Sign(_ io.Reader, digest []byte, _ crypto.SignerOpts) ([]byte, err
 	defer C.CFRelease(C.CFTypeRef(cfDigest))
 
 	var eref C.CFErrorRef
-	signature := C.SecKeyCreateSignature(C.SecKeyRef(key), C.kSecKeyAlgorithmECDSASignatureDigestX962, C.CFDataRef(cfDigest), &eref)
+	signature := C.SecKeyCreateSignature(C.SecKeyRef(key), C.kSecKeyAlgorithmECDSASignatureDigestX962SHA256, C.CFDataRef(cfDigest), &eref)
 	if err := goError(eref); err != nil {
 		return nil, err
 	}

--- a/enclavekey/sign_test.go
+++ b/enclavekey/sign_test.go
@@ -2,6 +2,7 @@ package enclavekey
 
 import (
 	"crypto/ecdsa"
+	"crypto/sha256"
 	"errors"
 	"testing"
 
@@ -38,7 +39,6 @@ func TestKey_Sign(t *testing.T) {
 				Tag:   "com.example.goapplesecurity.test.key",
 				Label: "example key",
 			},
-			wantErr: true,
 		},
 	}
 	for _, tt := range tests {
@@ -61,12 +61,14 @@ func TestKey_Sign(t *testing.T) {
 				t.Fatalf("error creating key: %v", err)
 			}
 
-			got, err := k.Sign(nil, tt.args.digest, nil)
+			digest := sha256.Sum256([]byte(tt.args.digest))
+
+			got, err := k.Sign(nil, digest[:], nil)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Key.Sign() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !tt.wantErr && !ecdsa.VerifyASN1(k.PublicKey, tt.args.digest, got) {
+			if !tt.wantErr && !ecdsa.VerifyASN1(k.PublicKey, digest[:], got) {
 				t.Errorf("invalid signature")
 			}
 		})


### PR DESCRIPTION
Allows the digest to be derived in Go rather than relying on the underlying Security framework implementation. This will make it easier in future to support additional digest and signing algorithms.
