### PR TITLE
Add List method for Generic Passwords, refactor keychain API

### DIFF
--- a/enclavekey/get_test.go
+++ b/enclavekey/get_test.go
@@ -43,7 +43,7 @@ func TestGet(t *testing.T) {
 				Tag:   tt.args.input.Tag,
 				Label: tt.args.input.Label,
 			})
-			if err != nil && !errors.Is(err, applesecurity.ErrNotFound) {
+			if err != nil && !errors.Is(err, applesecurity.ErrItemNotFound) {
 				t.Fatalf("error deleting existing keys: %v", err)
 			}
 

--- a/enclavekey/list.go
+++ b/enclavekey/list.go
@@ -61,7 +61,7 @@ func List(input ListInput) ([]Key, error) {
 	var resultsRef C.CFTypeRef
 	status := C.SecItemCopyMatching(C.CFDictionaryRef(query), &resultsRef)
 	err = goError(status)
-	if errors.Is(err, applesecurity.ErrNotFound) {
+	if errors.Is(err, applesecurity.ErrItemNotFound) {
 		// no items found, return nil.
 		return nil, nil
 	}

--- a/enclavekey/list_test.go
+++ b/enclavekey/list_test.go
@@ -53,7 +53,7 @@ func TestList(t *testing.T) {
 				Tag:   tt.args.input.Tag,
 				Label: tt.args.input.Label,
 			})
-			if err != nil && !errors.Is(err, applesecurity.ErrNotFound) {
+			if err != nil && !errors.Is(err, applesecurity.ErrItemNotFound) {
 				t.Fatalf("error deleting existing keys: %v", err)
 			}
 
@@ -86,7 +86,7 @@ func TestListReturnsAttributes(t *testing.T) {
 	_, err := Delete(DeleteInput{
 		Tag: tag,
 	})
-	if err != nil && !errors.Is(err, applesecurity.ErrNotFound) {
+	if err != nil && !errors.Is(err, applesecurity.ErrItemNotFound) {
 		t.Fatalf("error deleting existing keys: %v", err)
 	}
 

--- a/enclavekey/sign_test.go
+++ b/enclavekey/sign_test.go
@@ -48,7 +48,7 @@ func TestKey_Sign(t *testing.T) {
 				Tag:   tt.fields.Tag,
 				Label: tt.fields.Label,
 			})
-			if err != nil && !errors.Is(err, applesecurity.ErrNotFound) {
+			if err != nil && !errors.Is(err, applesecurity.ErrItemNotFound) {
 				t.Fatalf("error deleting existing keys: %v", err)
 			}
 

--- a/errors.go
+++ b/errors.go
@@ -60,9 +60,6 @@ var (
 	ErrUserCanceled = Error(C.errSecUserCanceled)
 	// ErrMissingEntitlement corresponds to errSecMissingEntitlement result code
 	ErrMissingEntitlement = Error(C.errSecMissingEntitlement)
-
-	// ErrNotFound occurs when a keychain item is not found.
-	ErrNotFound = Error(-25300)
 )
 
 // ErrorFromCode turns an error code into a Go error.
@@ -124,8 +121,6 @@ func (k Error) Error() (msg string) {
 		msg = "user canceled the operation"
 	case ErrMissingEntitlement:
 		msg = "a required entitlement is missing: ensure that your binary has been properly codesigned and has entitlements allowing keychain access"
-	case ErrNotFound:
-		msg = "the specified item could not be found in the keychain"
 	default:
 		msg = "keychain error"
 	}

--- a/keychain/add_generic_password.go
+++ b/keychain/add_generic_password.go
@@ -1,0 +1,53 @@
+package keychain
+
+/*
+#cgo LDFLAGS: -framework CoreFoundation -framework Security
+
+#include <CoreFoundation/CoreFoundation.h>
+#include <Security/Security.h>
+*/
+import "C"
+import (
+	applesecurity "github.com/common-fate/go-apple-security"
+	"github.com/common-fate/go-apple-security/corefoundation"
+)
+
+// AddGenericPassword adds a generic password to the keychain.
+//
+// Returns [ErrDuplicateItem] if the item already exists
+// for the provided account and service.
+func AddGenericPassword(input GenericPassword) error {
+	valueData, err := corefoundation.NewCFData(input.Data)
+	if err != nil {
+		return err
+	}
+	defer C.CFRelease(C.CFTypeRef(valueData))
+
+	cfAccount, err := corefoundation.NewCFString(input.Account)
+	if err != nil {
+		return err
+	}
+	defer C.CFRelease(C.CFTypeRef(cfAccount))
+
+	cfService, err := corefoundation.NewCFString(input.Service)
+	if err != nil {
+		return err
+	}
+	defer C.CFRelease(C.CFTypeRef(cfService))
+
+	attrs, err := corefoundation.NewCFDictionary(corefoundation.Dictionary{
+		corefoundation.TypeRef(C.kSecClass):                     corefoundation.TypeRef(C.kSecClassGenericPassword),
+		corefoundation.TypeRef(C.kSecUseDataProtectionKeychain): corefoundation.TypeRef(C.kCFBooleanTrue),
+		corefoundation.TypeRef(C.kSecValueData):                 corefoundation.TypeRef(valueData),
+		corefoundation.TypeRef(C.kSecAttrAccount):               corefoundation.TypeRef(cfAccount),
+		corefoundation.TypeRef(C.kSecAttrService):               corefoundation.TypeRef(cfService),
+	})
+	if err != nil {
+		return err
+	}
+	defer C.CFRelease(C.CFTypeRef(attrs))
+
+	errCode := C.SecItemAdd(C.CFDictionaryRef(attrs), nil)
+
+	return applesecurity.ErrorFromCode(int(errCode))
+}

--- a/keychain/delete_generic_password.go
+++ b/keychain/delete_generic_password.go
@@ -1,0 +1,59 @@
+package keychain
+
+/*
+#cgo LDFLAGS: -framework CoreFoundation -framework Security
+
+#include <CoreFoundation/CoreFoundation.h>
+#include <Security/Security.h>
+*/
+import "C"
+import (
+	"github.com/common-fate/go-apple-security/corefoundation"
+)
+
+type DeleteGenericPasswordsInput struct {
+	Account string
+	Service string
+}
+
+// DeleteGenericPasswords deletes matching items from the keychain.
+func DeleteGenericPasswords(input DeleteGenericPasswordsInput) (int, error) {
+	cfService, err := corefoundation.NewCFString(input.Service)
+	if err != nil {
+		return 0, err
+	}
+	defer C.CFRelease(C.CFTypeRef(cfService))
+
+	m := corefoundation.Dictionary{
+		corefoundation.TypeRef(C.kSecClass):                     corefoundation.TypeRef(C.kSecClassGenericPassword),
+		corefoundation.TypeRef(C.kSecUseDataProtectionKeychain): corefoundation.TypeRef(C.kCFBooleanTrue),
+		corefoundation.TypeRef(C.kSecAttrService):               corefoundation.TypeRef(cfService),
+	}
+
+	if input.Account != "" {
+		cfAccount, err := corefoundation.NewCFString(input.Account)
+		if err != nil {
+			return 0, err
+		}
+		defer C.CFRelease(C.CFTypeRef(cfAccount))
+
+		m[corefoundation.TypeRef(C.kSecAttrAccount)] = corefoundation.TypeRef(cfAccount)
+	}
+
+	query, err := corefoundation.NewCFDictionary(m)
+	if err != nil {
+		return 0, err
+	}
+	defer C.CFRelease(C.CFTypeRef(query))
+
+	var deleted int
+	var st C.OSStatus = C.errSecDuplicateItem
+	for st == C.errSecDuplicateItem {
+		st = C.SecItemDelete(C.CFDictionaryRef(query))
+		deleted++
+	}
+	if err := goError(st); err != nil {
+		return deleted, err
+	}
+	return deleted, nil
+}

--- a/keychain/errors.go
+++ b/keychain/errors.go
@@ -1,0 +1,42 @@
+package keychain
+
+/*
+#cgo LDFLAGS: -framework CoreFoundation -framework Security
+
+#include <CoreFoundation/CoreFoundation.h>
+#include <Security/Security.h>
+*/
+import "C"
+
+import (
+	"fmt"
+
+	applesecurity "github.com/common-fate/go-apple-security"
+)
+
+const (
+	nilCFError  C.CFErrorRef  = 0
+	nilCFString C.CFStringRef = 0
+)
+
+func goError(e interface{}) error {
+	if e == nil {
+		return nil
+	}
+
+	switch v := e.(type) {
+	case C.OSStatus:
+		return applesecurity.ErrorFromCode(int(v))
+
+	case C.CFErrorRef:
+		if v == nilCFError {
+			return nil
+		}
+
+		code := int(C.CFErrorGetCode(v))
+
+		return applesecurity.ErrorFromCode(code)
+	}
+
+	return fmt.Errorf("unknown error type %T", e)
+}

--- a/keychain/generic_password.go
+++ b/keychain/generic_password.go
@@ -8,11 +8,6 @@ package keychain
 */
 import "C"
 
-import (
-	applesecurity "github.com/common-fate/go-apple-security"
-	"github.com/common-fate/go-apple-security/corefoundation"
-)
-
 // GenericPassword is a generic password item.
 //
 // See: https://developer.apple.com/documentation/security/ksecclassgenericpassword
@@ -20,76 +15,4 @@ type GenericPassword struct {
 	Account string
 	Service string
 	Data    []byte
-}
-
-// Add the item to the keychain.
-//
-// Returns [ErrDuplicateItem] if the item already exists
-// for the provided account and service.
-func (p *GenericPassword) Add() error {
-	valueData, err := corefoundation.NewCFData(p.Data)
-	if err != nil {
-		return err
-	}
-	defer C.CFRelease(C.CFTypeRef(valueData))
-
-	cfAccount, err := corefoundation.NewCFString(p.Account)
-	if err != nil {
-		return err
-	}
-	defer C.CFRelease(C.CFTypeRef(cfAccount))
-
-	cfService, err := corefoundation.NewCFString(p.Service)
-	if err != nil {
-		return err
-	}
-	defer C.CFRelease(C.CFTypeRef(cfService))
-
-	attrs, err := corefoundation.NewCFDictionary(corefoundation.Dictionary{
-		corefoundation.TypeRef(C.kSecClass):                     corefoundation.TypeRef(C.kSecClassGenericPassword),
-		corefoundation.TypeRef(C.kSecUseDataProtectionKeychain): corefoundation.TypeRef(C.kCFBooleanTrue),
-		corefoundation.TypeRef(C.kSecValueData):                 corefoundation.TypeRef(valueData),
-		corefoundation.TypeRef(C.kSecAttrAccount):               corefoundation.TypeRef(cfAccount),
-		corefoundation.TypeRef(C.kSecAttrService):               corefoundation.TypeRef(cfService),
-	})
-	if err != nil {
-		return err
-	}
-	defer C.CFRelease(C.CFTypeRef(attrs))
-
-	errCode := C.SecItemAdd(C.CFDictionaryRef(attrs), nil)
-
-	return applesecurity.ErrorFromCode(int(errCode))
-}
-
-// Remove the item from the keychain.
-//
-// Note: this does not return an error if the item doesn't exist.
-func (p *GenericPassword) Remove() error {
-	cfAccount, err := corefoundation.NewCFString(p.Account)
-	if err != nil {
-		return err
-	}
-	defer C.CFRelease(C.CFTypeRef(cfAccount))
-
-	cfService, err := corefoundation.NewCFString(p.Service)
-	if err != nil {
-		return err
-	}
-	defer C.CFRelease(C.CFTypeRef(cfService))
-
-	attrs, err := corefoundation.NewCFDictionary(corefoundation.Dictionary{
-		corefoundation.TypeRef(C.kSecClass):                     corefoundation.TypeRef(C.kSecClassGenericPassword),
-		corefoundation.TypeRef(C.kSecUseDataProtectionKeychain): corefoundation.TypeRef(C.kCFBooleanTrue),
-		corefoundation.TypeRef(C.kSecAttrAccount):               corefoundation.TypeRef(cfAccount),
-		corefoundation.TypeRef(C.kSecAttrService):               corefoundation.TypeRef(cfService),
-	})
-	if err != nil {
-		return err
-	}
-	defer C.CFRelease(C.CFTypeRef(attrs))
-
-	errCode := C.SecItemDelete(C.CFDictionaryRef(attrs))
-
-	return applesecurity.ErrorFromCode(int(errCode))
 }

--- a/keychain/generic_password_test.go
+++ b/keychain/generic_password_test.go
@@ -1,21 +1,21 @@
 package keychain
 
-import "testing"
+import (
+	"errors"
+	"testing"
+
+	applesecurity "github.com/common-fate/go-apple-security"
+)
 
 func TestGenericPassword_AddRemove(t *testing.T) {
-	type fields struct {
-		Account string
-		Service string
-		Data    []byte
-	}
 	tests := []struct {
 		name    string
-		fields  fields
+		input   GenericPassword
 		wantErr bool
 	}{
 		{
 			name: "ok",
-			fields: fields{
+			input: GenericPassword{
 				Account: "foo",
 				Service: "bar",
 				Data:    []byte("hello"),
@@ -24,20 +24,17 @@ func TestGenericPassword_AddRemove(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := &GenericPassword{
-				Account: tt.fields.Account,
-				Service: tt.fields.Service,
-				Data:    tt.fields.Data,
-			}
-
 			// remove any existing keychain item,
 			// otherwise Add will always fail.
-			err := p.Remove()
-			if err != nil {
+			_, err := DeleteGenericPasswords(DeleteGenericPasswordsInput{
+				Account: tt.input.Account,
+				Service: tt.input.Service,
+			})
+			if err != nil && !errors.Is(err, applesecurity.ErrItemNotFound) {
 				t.Fatal(err)
 			}
 
-			if err := p.Add(); (err != nil) != tt.wantErr {
+			if err := AddGenericPassword(tt.input); (err != nil) != tt.wantErr {
 				t.Errorf("GenericPassword.Add() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/keychain/get_generic_password.go
+++ b/keychain/get_generic_password.go
@@ -1,0 +1,58 @@
+package keychain
+
+/*
+#cgo LDFLAGS: -framework CoreFoundation -framework Security
+
+#include <CoreFoundation/CoreFoundation.h>
+#include <Security/Security.h>
+*/
+import "C"
+import (
+	"github.com/common-fate/go-apple-security/corefoundation"
+)
+
+const (
+	nilCFData C.CFDataRef = 0
+)
+
+type GetGenericPasswordInput struct {
+	Account string
+	Service string
+}
+
+func GetGenericPassword(input GetGenericPasswordInput) (*GenericPassword, error) {
+	cfAccount, err := corefoundation.NewCFString(input.Account)
+	if err != nil {
+		return nil, err
+	}
+	defer C.CFRelease(C.CFTypeRef(cfAccount))
+
+	cfService, err := corefoundation.NewCFString(input.Service)
+	if err != nil {
+		return nil, err
+	}
+	defer C.CFRelease(C.CFTypeRef(cfService))
+
+	query, err := corefoundation.NewCFDictionary(corefoundation.Dictionary{
+		corefoundation.TypeRef(C.kSecClass):                     corefoundation.TypeRef(C.kSecClassGenericPassword),
+		corefoundation.TypeRef(C.kSecUseDataProtectionKeychain): corefoundation.TypeRef(C.kCFBooleanTrue),
+		corefoundation.TypeRef(C.kSecAttrAccount):               corefoundation.TypeRef(cfAccount),
+		corefoundation.TypeRef(C.kSecAttrService):               corefoundation.TypeRef(cfService),
+		corefoundation.TypeRef(C.kSecReturnAttributes):          corefoundation.TypeRef(C.kCFBooleanTrue),
+		corefoundation.TypeRef(C.kSecReturnData):                corefoundation.TypeRef(C.kCFBooleanTrue),
+		corefoundation.TypeRef(C.kSecMatchLimit):                corefoundation.TypeRef(C.kSecMatchLimitOne),
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer C.CFRelease(C.CFTypeRef(query))
+
+	var itemRef C.CFTypeRef
+	status := C.SecItemCopyMatching(C.CFDictionaryRef(query), &itemRef)
+	if err := goError(status); err != nil {
+		return nil, err
+	}
+	defer C.CFRelease(itemRef)
+
+	return extractGenericPassword(C.CFDictionaryRef(itemRef))
+}

--- a/keychain/get_generic_password_test.go
+++ b/keychain/get_generic_password_test.go
@@ -1,0 +1,67 @@
+package keychain
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	applesecurity "github.com/common-fate/go-apple-security"
+)
+
+func TestGetGenericPassword(t *testing.T) {
+	type args struct {
+		input GetGenericPasswordInput
+		data  []byte
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *GenericPassword
+		wantErr bool
+	}{
+		{
+			name: "ok",
+			args: args{
+				input: GetGenericPasswordInput{
+					Service: "test",
+					Account: "example test account",
+				},
+				data: []byte("hello"),
+			},
+			want: &GenericPassword{
+				Account: "example test account",
+				Service: "test",
+				Data:    []byte("hello"),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := DeleteGenericPasswords(DeleteGenericPasswordsInput{
+				Account: tt.args.input.Account,
+				Service: tt.args.input.Service,
+			})
+			if err != nil && !errors.Is(err, applesecurity.ErrItemNotFound) {
+				t.Fatal(err)
+			}
+
+			err = AddGenericPassword(GenericPassword{
+				Account: tt.args.input.Account,
+				Service: tt.args.input.Service,
+				Data:    tt.args.data,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			got, err := GetGenericPassword(tt.args.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetGenericPassword() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetGenericPassword() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/keychain/list_generic_passwords.go
+++ b/keychain/list_generic_passwords.go
@@ -1,0 +1,98 @@
+package keychain
+
+/*
+#cgo LDFLAGS: -framework CoreFoundation -framework Security
+
+#include <CoreFoundation/CoreFoundation.h>
+#include <Security/Security.h>
+*/
+import "C"
+import (
+	"errors"
+	"fmt"
+	"unsafe"
+
+	applesecurity "github.com/common-fate/go-apple-security"
+	"github.com/common-fate/go-apple-security/corefoundation"
+)
+
+type ListGenericPasswordsInput struct {
+	Service string
+}
+
+func ListGenericPasswords(input ListGenericPasswordsInput) ([]GenericPassword, error) {
+	cfService, err := corefoundation.NewCFString(input.Service)
+	if err != nil {
+		return nil, err
+	}
+	defer C.CFRelease(C.CFTypeRef(cfService))
+
+	query, err := corefoundation.NewCFDictionary(corefoundation.Dictionary{
+		corefoundation.TypeRef(C.kSecClass):                     corefoundation.TypeRef(C.kSecClassGenericPassword),
+		corefoundation.TypeRef(C.kSecUseDataProtectionKeychain): corefoundation.TypeRef(C.kCFBooleanTrue),
+		corefoundation.TypeRef(C.kSecAttrService):               corefoundation.TypeRef(cfService),
+		corefoundation.TypeRef(C.kSecReturnAttributes):          corefoundation.TypeRef(C.kCFBooleanTrue),
+		corefoundation.TypeRef(C.kSecReturnData):                corefoundation.TypeRef(C.kCFBooleanTrue),
+		corefoundation.TypeRef(C.kSecMatchLimit):                corefoundation.TypeRef(C.kSecMatchLimitAll),
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer C.CFRelease(C.CFTypeRef(query))
+
+	var resultsRef C.CFTypeRef
+	status := C.SecItemCopyMatching(C.CFDictionaryRef(query), &resultsRef)
+	err = goError(status)
+	if errors.Is(err, applesecurity.ErrItemNotFound) {
+		// no items found, return nil.
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer C.CFRelease(resultsRef)
+
+	var results []GenericPassword
+
+	arr := corefoundation.CFArrayToArray(corefoundation.ArrayRef(resultsRef))
+	for _, ref := range arr {
+		elementTypeID := C.CFGetTypeID(C.CFTypeRef(ref))
+		if elementTypeID != C.CFDictionaryGetTypeID() {
+			return nil, fmt.Errorf("Invalid result type within array: %s", CFTypeDescription(C.CFTypeRef(ref)))
+		}
+
+		key, err := extractGenericPassword(C.CFDictionaryRef(ref))
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, *key)
+	}
+
+	return results, nil
+}
+
+func extractGenericPassword(ref C.CFDictionaryRef) (*GenericPassword, error) {
+	val := C.CFDataRef(C.CFDictionaryGetValue(ref, unsafe.Pointer(C.kSecValueData)))
+	if val == nilCFData {
+		return nil, fmt.Errorf("cannot extract data")
+	}
+
+	p := GenericPassword{
+		Data: C.GoBytes(
+			unsafe.Pointer(C.CFDataGetBytePtr(val)),
+			C.int(C.CFDataGetLength(val)),
+		),
+		Account: corefoundation.GetDictionaryStringValue(corefoundation.DictionaryRef(ref), corefoundation.StringRef(C.kSecAttrAccount)),
+		Service: corefoundation.GetDictionaryStringValue(corefoundation.DictionaryRef(ref), corefoundation.StringRef(C.kSecAttrService)),
+	}
+
+	return &p, nil
+}
+
+// CFTypeDescription returns type string for CFTypeRef.
+func CFTypeDescription(ref C.CFTypeRef) string {
+	typeID := C.CFGetTypeID(ref)
+	typeDesc := C.CFCopyTypeIDDescription(typeID)
+	defer C.CFRelease(C.CFTypeRef(typeDesc))
+	return corefoundation.CFStringToString(corefoundation.StringRef(typeDesc))
+}

--- a/keychain/list_generic_passwords_test.go
+++ b/keychain/list_generic_passwords_test.go
@@ -1,0 +1,81 @@
+package keychain
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	applesecurity "github.com/common-fate/go-apple-security"
+)
+
+func TestListGenericPasswords(t *testing.T) {
+	type args struct {
+		input ListGenericPasswordsInput
+	}
+	tests := []struct {
+		name    string
+		args    args
+		insert  []GenericPassword
+		want    []GenericPassword
+		wantErr bool
+	}{
+		{
+			name: "ok",
+			args: args{
+				input: ListGenericPasswordsInput{
+					Service: "foo",
+				},
+			},
+			insert: []GenericPassword{
+				{
+					Account: "test1",
+					Service: "foo",
+					Data:    []byte("hello"),
+				},
+				{
+					Account: "test2",
+					Service: "foo",
+					Data:    []byte("hello2"),
+				},
+			},
+			want: []GenericPassword{
+				{
+					Account: "test1",
+					Service: "foo",
+					Data:    []byte("hello"),
+				},
+				{
+					Account: "test2",
+					Service: "foo",
+					Data:    []byte("hello2"),
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := DeleteGenericPasswords(DeleteGenericPasswordsInput{
+				Service: tt.args.input.Service,
+			})
+			if err != nil && !errors.Is(err, applesecurity.ErrItemNotFound) {
+				t.Fatal(err)
+			}
+
+			for _, p := range tt.insert {
+				err = AddGenericPassword(p)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			got, err := ListGenericPasswords(tt.args.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ListGenericPasswords() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ListGenericPasswords() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Allows listing keychain generic passwords.

Improves the delete API to handle deleting multiple items for a particular service - which allows us to clear all items in the keychain with cached credentials.
