### PR TITLE
Add UpdateGenericPassword method

### DIFF
--- a/keychain/update_generic_password.go
+++ b/keychain/update_generic_password.go
@@ -1,0 +1,60 @@
+package keychain
+
+/*
+#cgo LDFLAGS: -framework CoreFoundation -framework Security
+
+#include <CoreFoundation/CoreFoundation.h>
+#include <Security/Security.h>
+*/
+import "C"
+import (
+	applesecurity "github.com/common-fate/go-apple-security"
+	"github.com/common-fate/go-apple-security/corefoundation"
+)
+
+// UpdateGenericPassword updates a generic password in the keychain.
+func UpdateGenericPassword(input GenericPassword) error {
+	valueData, err := corefoundation.NewCFData(input.Data)
+	if err != nil {
+		return err
+	}
+	defer C.CFRelease(C.CFTypeRef(valueData))
+
+	cfAccount, err := corefoundation.NewCFString(input.Account)
+	if err != nil {
+		return err
+	}
+	defer C.CFRelease(C.CFTypeRef(cfAccount))
+
+	cfService, err := corefoundation.NewCFString(input.Service)
+	if err != nil {
+		return err
+	}
+	defer C.CFRelease(C.CFTypeRef(cfService))
+
+	query, err := corefoundation.NewCFDictionary(corefoundation.Dictionary{
+		corefoundation.TypeRef(C.kSecClass):                     corefoundation.TypeRef(C.kSecClassGenericPassword),
+		corefoundation.TypeRef(C.kSecUseDataProtectionKeychain): corefoundation.TypeRef(C.kCFBooleanTrue),
+		corefoundation.TypeRef(C.kSecValueData):                 corefoundation.TypeRef(valueData),
+		corefoundation.TypeRef(C.kSecAttrAccount):               corefoundation.TypeRef(cfAccount),
+		corefoundation.TypeRef(C.kSecAttrService):               corefoundation.TypeRef(cfService),
+	})
+	if err != nil {
+		return err
+	}
+	defer C.CFRelease(C.CFTypeRef(query))
+
+	attrs, err := corefoundation.NewCFDictionary(corefoundation.Dictionary{
+		corefoundation.TypeRef(C.kSecValueData):   corefoundation.TypeRef(valueData),
+		corefoundation.TypeRef(C.kSecAttrAccount): corefoundation.TypeRef(cfAccount),
+		corefoundation.TypeRef(C.kSecAttrService): corefoundation.TypeRef(cfService),
+	})
+	if err != nil {
+		return err
+	}
+	defer C.CFRelease(C.CFTypeRef(attrs))
+
+	errCode := C.SecItemUpdate(C.CFDictionaryRef(query), C.CFDictionaryRef(attrs))
+
+	return applesecurity.ErrorFromCode(int(errCode))
+}

--- a/keychain/update_generic_password_test.go
+++ b/keychain/update_generic_password_test.go
@@ -1,0 +1,49 @@
+package keychain
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	applesecurity "github.com/common-fate/go-apple-security"
+)
+
+func TestUpdateGenericPassword(t *testing.T) {
+	pw := GenericPassword{
+		Account: "bar",
+		Service: "foo",
+		Data:    []byte("first"),
+	}
+
+	_, err := DeleteGenericPasswords(DeleteGenericPasswordsInput{
+		Account: pw.Account,
+		Service: pw.Service,
+	})
+	if err != nil && !errors.Is(err, applesecurity.ErrItemNotFound) {
+		t.Fatal(err)
+	}
+
+	err = AddGenericPassword(pw)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pw.Data = []byte("second")
+
+	err = UpdateGenericPassword(pw)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := GetGenericPassword(GetGenericPasswordInput{
+		Account: pw.Account,
+		Service: pw.Service,
+	})
+	if err != nil {
+		t.Errorf("GetGenericPassword() error = %v, wantErr %v", err, false)
+		return
+	}
+	if !reflect.DeepEqual(got, &pw) {
+		t.Errorf("GetGenericPassword() = %v, want %v", got, pw)
+	}
+}


### PR DESCRIPTION
Adds `UpdateGenericPassword` method.

Added because `AddGenericPassword` returns an error if you try and overwrite an existing keychain item.
